### PR TITLE
use a blueprint for ignition.firstboot

### DIFF
--- a/00-fcos.toml
+++ b/00-fcos.toml
@@ -5,7 +5,7 @@ type = "xfs"
 # as b-i-b does not support yet adding ignition osbuild stage to the generated manifest
 # remove those kargs once supported.
 [install]
-kargs = ["rw", "console=tty0", "console=ttyS0", "ignition.firstboot", "ignition.platform.id=qemu"]
+kargs = ["rw", "console=tty0", "console=ttyS0", "$ignition_firstboot", "ignition.platform.id=qemu"]
 # We dont't want bootc to append the kargs list with boot=UUID= and root=UUID= info
 # as CoreOS already handles this.
 root-mount-spec = ""

--- a/Containerfile-cosa
+++ b/Containerfile-cosa
@@ -1,2 +1,4 @@
 FROM quay.io/jbtrystramtestimages/cosa:latest
 RUN sudo chmod -R 644 /boot/initramfs*
+RUN sudo dnf install -y libvirt-devel libvirt-libs
+COPY ./image-builder /usr/bin/image-builder

--- a/README.md
+++ b/README.md
@@ -37,8 +37,12 @@ alias ibc='sudo podman run --rm --privileged \
 # Get rid of this line below once https://github.com/osbuild/images/pull/2231 is merged, and 
 # contained in a new osbuild/images release which is included in i-b-c
 # Then uncomment the line above
-BUILDER_IMAGE=localhost/cosa-of-ib
-sudo podman build -f Containerfile-cosa -t $BUILDER_IMAGE
+# Also integrate a build of 
+# https://github.com/osbuild/images/pull/2222
+BUILDER_IMAGE=quay.io/jbtrystramtestimages/cosa-ib
+#sudo podman build -f Containerfile-cosa -t $BUILDER_IMAGE
+
+alias ibc='sudo podman run --rm --privileged --network=none -v /var/lib/containers/storage:/var/lib/containers/storage -v ./output:/output -v ./fcos-bp.toml:/fcos-bp.toml $BUILDER_IMAGE'
 
 # Generate the disk image
 ibc build qcow2 \
@@ -48,7 +52,8 @@ ibc build qcow2 \
           --output-name fedora-coreos-rawhide \
           --with-buildlog \
           --with-manifest \
-          --with-metrics
+          --with-metrics \
+          --blueprint /fcos-bp.toml
 
 # Check the osbuild manifest that was generated and used
 jq . output/fedora-coreos/fedora-coreos-rawhide.osbuild-manifest.json

--- a/fcos-bp.toml
+++ b/fcos-bp.toml
@@ -1,0 +1,4 @@
+name = "Fedora CoreOS"
+
+[customizations.ignition.firstboot]
+empty = true


### PR DESCRIPTION
 This requires a local build of https://github.com/osbuild/images/pull/2222
    
Then to test:

```
    IBC_IMAGE=localhost/ibc
    sudo podman build -t localhost/ibc -f Containerfile-ibc
    
    alias ibc='sudo podman run --rm --privileged --network=none -v /var/lib/containers/storage:/var/lib/containers/storage -v ./output:/output -v ./fcos-bp.toml:/fcos-bp.toml $IBC_IMAGE'
    
    ibc build qcow2 \
              --bootc-build-ref $BUILDER_IMAGE \
              --bootc-ref $TARGET_FCOS_IMAGE \
              --output-dir fedora-coreos \
              --output-name fedora-coreos-rawhide \
              --with-buildlog \
              --with-manifest \
              --with-metrics --blueprint /fcos-bp.toml
```
