### PR TITLE
tekton: derive artifact list from artifacts.yaml

### DIFF
--- a/.tekton/disk-images-rawhide-pull-request.yaml
+++ b/.tekton/disk-images-rawhide-pull-request.yaml
@@ -28,10 +28,6 @@ spec:
     value: quay.io/konflux-fedora/coreos-tenant/disk-images-rawhide:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: artifacts
-    value:
-      - qemu
-      - metal
   - name: output-name
     value: fedora-coreos-rawhide
   - name: source-image
@@ -64,12 +60,6 @@ spec:
     - default: "false"
       description: Enable cache proxy configuration
       name: enable-cache-proxy
-    - description: List of artifact types to build (e.g. ["qemu", "metal"]).
-      name: artifacts
-      type: array
-      default:
-        - qemu
-        - metal
     - description: Base name for the produced disk image file (--output-name).
       name: output-name
       type: string
@@ -122,9 +112,8 @@ spec:
       params:
       - name: PLATFORM
         value: linux/amd64
-      - name: ARTIFACTS
-        value:
-          - $(params.artifacts[*])
+      - name: ARTIFACTS_FILE
+        value: artifacts.yaml
       - name: SOURCE_IMAGE
         value: $(params.source-image)
       - name: OUTPUT_IMAGE

--- a/.tekton/disk-images-rawhide-push.yaml
+++ b/.tekton/disk-images-rawhide-push.yaml
@@ -27,10 +27,6 @@ spec:
     value: quay.io/konflux-fedora/coreos-tenant/disk-images-rawhide:{{revision}}
   - name: image-expires-after
     value: ""
-  - name: artifacts
-    value:
-      - qemu
-      - metal
   - name: output-name
     value: fedora-coreos-rawhide
   - name: source-image
@@ -63,12 +59,6 @@ spec:
     - default: "false"
       description: Enable cache proxy configuration
       name: enable-cache-proxy
-    - description: List of artifact types to build (e.g. ["qemu", "metal"]).
-      name: artifacts
-      type: array
-      default:
-        - qemu
-        - metal
     - description: Base name for the produced disk image file (--output-name).
       name: output-name
       type: string
@@ -121,9 +111,8 @@ spec:
       params:
       - name: PLATFORM
         value: linux/amd64
-      - name: ARTIFACTS
-        value:
-          - $(params.artifacts[*])
+      - name: ARTIFACTS_FILE
+        value: artifacts.yaml
       - name: SOURCE_IMAGE
         value: $(params.source-image)
       - name: OUTPUT_IMAGE

--- a/.tekton/tasks/image-builder.yaml
+++ b/.tekton/tasks/image-builder.yaml
@@ -11,10 +11,11 @@ metadata:
       Build multiple Fedora CoreOS disk images using image-builder-cli running
       on an arch-native remote VM provisioned by the Konflux multi-platform-controller.
 
-      This task builds all specified artifacts (e.g. qemu, metal) for a single
-      architecture in the same VM. Each artifact is pushed individually as an
-      OCI artifact with a config JSON carrying platform metadata
-      (os=<artifact>, architecture=<arch>).
+      This task builds all artifacts defined in artifacts.yaml for a
+      single architecture in the same VM. The artifact list is derived from
+      default_artifacts.all merged with default_artifacts.<arch>. Each artifact
+      is pushed individually as an OCI artifact with a config JSON carrying
+      platform metadata (os=<artifact>, architecture=<arch>).
 
       Blueprints and disk layout are read directly from the cloned repository.
 
@@ -44,14 +45,6 @@ spec:
         Supported values: linux/amd64, linux/arm64, linux/ppc64le, linux/s390x.
         The arch component is translated to Fedora naming (x86_64, aarch64, etc.)
         and used to locate disk/<arch>.yaml and <artifact>/<arch>.toml.
-
-    - name: ARTIFACTS
-      type: array
-      description: >
-        List of artifact types to build. Each must match a top-level directory
-        in the repository that contains per-arch blueprints (e.g. "qemu", "metal").
-        Controls the image type passed to image-builder-cli and the blueprint
-        path used. Artifacts without blueprints for the target arch are skipped.
 
     - name: SOURCE_IMAGE
       type: string
@@ -93,6 +86,15 @@ spec:
           builder-image: <pullspec>       — bootc builder image (--bootc-build-ref)
         This file is the single source of truth for image references,
         making it easy for MintMaker to bump digests automatically.
+
+    - name: ARTIFACTS_FILE
+      type: string
+      default: "artifacts.yaml"
+      description: >
+        Path (relative to the repo root) to the pipeline config file containing
+        the default_artifacts map. The artifact list for the target architecture
+        is derived from default_artifacts.all merged with default_artifacts.<arch>.
+        Artifacts without blueprints for the target arch are silently skipped.
 
     - name: OUTPUT_NAME
       type: string
@@ -138,6 +140,8 @@ spec:
         value: $(params.STORAGE_DRIVER)
       - name: ORAS_IMAGE
         value: $(params.ORAS_IMAGE)
+      - name: ARTIFACTS_FILE
+        value: $(params.ARTIFACTS_FILE)
     volumeMounts:
       - name: workdir
         mountPath: /var/workdir
@@ -159,7 +163,7 @@ spec:
         - $(params.SOURCE_ARTIFACT)=/var/workdir/source
 
     # -------------------------------------------------------------------------
-    # 2. Parse image-builder config file and export variables for the build.
+    # 2. Parse config files and export variables for the build.
     # -------------------------------------------------------------------------
     - name: validate-config
       image: quay.io/konflux-ci/task-runner:1.7.0@sha256:1c0582a85dae0949f3ec94aca95695c5d7698b371f1b76c5a78822a6249073dc
@@ -173,8 +177,11 @@ spec:
         #!/bin/bash
         set -euo pipefail
 
+        # ------------------------------------------------------------------
+        # Parse image-builder-config.yaml for image pullspecs
+        # ------------------------------------------------------------------
         CONFIG="/var/workdir/source/${IMAGE_BUILDER_CONFIG_FILE}"
-        echo "Reading config from: ${CONFIG}"
+        echo "Reading image-builder config from: ${CONFIG}"
 
         if [ ! -f "${CONFIG}" ]; then
           echo "ERROR: config file not found: ${CONFIG}"
@@ -196,8 +203,38 @@ spec:
 
         echo "declare IBC_IMAGE=${IBC_IMAGE}" > /var/workdir/config-vars
         echo "declare BUILDER_IMAGE=${BUILDER_IMAGE}" >> /var/workdir/config-vars
-        echo "Config validated:"
+        echo "Image-builder config validated:"
         cat /var/workdir/config-vars
+
+        # ------------------------------------------------------------------
+        # Parse artifacts.yaml for the artifact list
+        # Merge default_artifacts.all with default_artifacts.<arch>
+        # ------------------------------------------------------------------
+        OCI_ARCH="${PLATFORM##*/}"
+        case "${OCI_ARCH}" in
+          amd64) ARCH="x86_64"  ;;
+          arm64) ARCH="aarch64" ;;
+          *)     ARCH="${OCI_ARCH}" ;;
+        esac
+
+        PIPELINE_CONFIG="/var/workdir/source/${ARTIFACTS_FILE}"
+        echo "Reading pipeline config from: ${PIPELINE_CONFIG}"
+
+        if [ ! -f "${PIPELINE_CONFIG}" ]; then
+          echo "ERROR: pipeline config file not found: ${PIPELINE_CONFIG}"
+          exit 1
+        fi
+
+        # Merge .default_artifacts.all and .default_artifacts.<arch> into a
+        # single newline-separated list, then write it to artifacts.txt
+        yq -r '
+          (.default_artifacts.all // []) +
+          (.default_artifacts["'"${ARCH}"'"] // [])
+          | .[]
+        ' "${PIPELINE_CONFIG}" > /var/workdir/artifacts.txt
+
+        echo "Artifacts to build for ${ARCH}:"
+        cat /var/workdir/artifacts.txt
 
     # -------------------------------------------------------------------------
     # 3. Build and push multiple disk images on the arch-native remote VM.
@@ -214,7 +251,6 @@ spec:
         - name: ssh
           mountPath: /ssh
           readOnly: true
-      args: ["$(params.ARTIFACTS[*])"]
       script: |
         #!/bin/bash
         set -e
@@ -293,10 +329,6 @@ spec:
 
         echo "ARCH: '${ARCH}'"
         echo "OCI_ARCH: '${OCI_ARCH}'"
-        echo "ARTIFACTS: $@"
-
-        # Write artifacts list to a file for the remote script
-        printf '%s\n' "$@" > /var/workdir/artifacts.txt
 
         rsync -e "ssh ${SSH_ARGS[*]}" -ra /var/workdir/artifacts.txt "$SSH_HOST:$BUILD_DIR/artifacts.txt"
 

--- a/artifacts.yaml
+++ b/artifacts.yaml
@@ -1,0 +1,44 @@
+# Sourced from coreos/fedora-coreos-pipeline config.yaml
+# This file controls which disk image artifacts are built per architecture
+# in Konflux. 
+# Artifacts listed under "all" are built for every architecture.
+# Architecture-specific lists are merged with "all" at build time.
+default_artifacts:
+  all:
+    - qemu
+    - metal
+    - metal4k
+    - live
+    - openstack
+  aarch64:
+    - applehv
+    - aws
+    - azure
+    - gcp
+    - hetzner
+    - hyperv
+    - oraclecloud
+  ppc64le:
+    - powervs
+  s390x:
+    - ibmcloud
+    - kubevirt
+  x86_64:
+    - aliyun
+    - applehv
+    - aws
+    - azure
+    - azurestack
+    - digitalocean
+    - exoscale
+    - gcp
+    - hetzner
+    - hyperv
+    - ibmcloud
+    - kubevirt
+    - nutanix
+    - oraclecloud
+    - proxmoxve
+    - virtualbox
+    - vmware
+    - vultr


### PR DESCRIPTION
Add artifacts_config.yaml to the repo root containing the default_artifacts map sourced from coreos/fedora-coreos-pipeline config.yaml.

The artifact list is a build-time argument that cannot be loaded dynamically from an external source. Any change to what gets built must go through a commit to this repo, triggering a new Konflux build.

The image-builder task now reads default_artifacts.all merged with default_artifacts.<arch> from this file via the ARTIFACTS_FILE param (default: artifacts_config.yaml) in the validate-config step, writing the result to artifacts.txt for the remote build script.

The hard-coded artifacts: [qemu, metal] param is removed from both PipelineRun definitions.