### PR TITLE
blueprints: hint disk image size in blueprint for cloud images

### DIFF
--- a/blueprints/generated/qemu-x86_64.toml
+++ b/blueprints/generated/qemu-x86_64.toml
@@ -16,3 +16,6 @@ append = "mitigations=auto,nosmt $ignition_firstboot ignition.platform.id=qemu c
 terminal_input = ["serial", "console"]
 terminal_output = ["serial", "console"]
 serial = "serial --speed=115200"
+
+[customizations.disk]
+minsize = "10GiB"

--- a/blueprints/sources/qemu/x86_64.toml
+++ b/blueprints/sources/qemu/x86_64.toml
@@ -7,3 +7,6 @@ append = "ignition.platform.id=qemu console=tty0 console=ttyS0,115200n8"
 terminal_input = ["serial", "console"]
 terminal_output = ["serial", "console"]
 serial = "serial --speed=115200"
+
+[customizations.disk]
+minsize = "10GiB"


### PR DESCRIPTION
Instead of having the disk size enforced in the partition table we can have a hint in the cloud image blueprints.

Requires https://github.com/coreos/fedora-coreos-config/pull/4259/commits/ede1afaafdef46e739a2b4c0cad7eb8431144ee8

Another approach would be to use the `--image-size` CLI flag.